### PR TITLE
DCNM HTTPAPI Connection Plugin and Test Module

### DIFF
--- a/lib/ansible/modules/network/dcnm/dcnm_rest.py
+++ b/lib/ansible/modules/network/dcnm/dcnm_rest.py
@@ -1,0 +1,103 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""dcnm_rest module
+Copyright (c) 2019 Cisco and/or its affiliates.
+This software is licensed to you under the terms of the Cisco Sample
+Code License, Version 1.0 (the "License"). You may obtain a copy of the
+License at
+               https://developer.cisco.com/docs/licenses
+All use of the material herein must be in accordance with the terms of
+the License. All rights not expressly granted by the License are
+reserved. Unless required by applicable law or agreed to separately in
+writing, software distributed under the License is distributed on an "AS
+IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied.
+"""
+
+__copyright__ = "Copyright (c) 2019 Cisco and/or its affiliates."
+__license__ = "Cisco Sample Code License, Version 1.0"
+__author__ = "Mike Wiebe"
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: dcnm_rest
+short_description: Send REST API requests to DCNM controller.
+version_added: "2.10"
+description:
+    - "Send REST API requests to DCNM controller."
+options:
+  method:
+    description:
+    - 'REST API Method'
+    required: yes
+    choices: ['GET', 'POST', 'PUT', 'DELETE']
+  path:
+    description:
+    - 'REST API Path Endpoint'
+    required: yes
+  json_data:
+    description:
+    - 'Additional JSON data to include with the REST API call'
+    required: no
+author:
+    - Mike Wiebe (@mikewiebe)
+'''
+
+EXAMPLES = '''
+- name: Gather List of Fabrics from DCNM
+  dcnm_rest:
+    method: GET
+    path: /rest/control/fabrics
+'''
+
+RETURN = '''
+response:
+    description: Success or Error Data retrieved from DCNM
+    type: list
+    elements: dict
+'''
+
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    # define available arguments/parameters a user can pass to the module
+    argument_spec = dict(
+        method=dict(required=True, choices=['GET', 'POST', 'PUT', 'DELETE']),
+        path=dict(required=True, type='str'),
+        json_data=dict(type='raw', required=False, default=None))
+
+    # seed the result dict
+    result = dict(
+        changed=False,
+        response=dict()
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    method = module.params['method']
+    path = module.params['path']
+    json_data = {}
+    if module.params['json_data'] is not None:
+        json_data = module.params['json_data']
+
+    conn = Connection(module._socket_path)
+    result['response'] = conn.send_request(method, path, json_data)
+    if result['response'][0].get('ERROR'):
+        module.fail_json(msg=result['response'])
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/plugins/httpapi/dcnm.py
+++ b/lib/ansible/plugins/httpapi/dcnm.py
@@ -7,8 +7,9 @@ author: Mike Wiebe (mikewiebe)
 httpapi: dcnm
 short_description: Send REST api calls to Data Center Network Manager (DCNM) NX-OS Fabric Controller.
 description:
-  - This DCNM plugin provides abstraction api's for sending and receiving
-    REST api calls to the DCNM Controller.
+  - This DCNM plugin provides the HTTPAPI transport methods needed to initiate
+    a connection to the DCNM controller, send API requests and process the
+    respsonse from the controller.
 version_added: "2.10"
 """
 

--- a/lib/ansible/plugins/httpapi/dcnm.py
+++ b/lib/ansible/plugins/httpapi/dcnm.py
@@ -1,0 +1,111 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+author: Mike Wiebe (mikewiebe)
+httpapi: dcnm
+short_description: Send REST api calls to Data Center Network Manager (DCNM) NX-OS Fabric Controller.
+description:
+  - This DCNM plugin provides abstraction api's for sending and receiving
+    REST api calls to the DCNM Controller.
+version_added: "2.10"
+"""
+
+import json
+import re
+import collections
+import requests
+import sys
+
+from ansible.module_utils._text import to_text
+from ansible.module_utils.connection import ConnectionError
+from ansible.module_utils.network.common.utils import to_list
+from ansible.plugins.httpapi import HttpApiBase
+
+
+class HttpApi(HttpApiBase):
+
+    def __init__(self, *args, **kwargs):
+        super(HttpApi, self).__init__(*args, **kwargs)
+        self.headers = {
+            'Content-Type': "application/json",
+            'Dcnm-Token': None
+        }
+
+    def login(self, username, password):
+        ''' DCNM Login Method.  This method is automatically called by the
+            Ansible plugin architecture if an active Dcnm-Token is not already
+            available.
+        '''
+        method = 'POST'
+        path = '/rest/logon'
+        data = "{'expirationTime': 60000}"
+
+        try:
+            response, response_data = self.connection.send(path, data, method=method, headers=self.headers, force_basic_auth=True)
+            response_value = self._get_response_value(response_data)
+            self.headers['Dcnm-Token'] = self._response_to_json(response_value)['Dcnm-Token']
+        except Exception as e:
+            msg = 'Error on attempt to connect and authenticate with DCNM controller: {}'.format(e)
+            raise Exception(self._return_error(None, method, path, msg))
+
+    def send_request(self, method, path, json=None):
+        ''' This method handles all DCNM REST API requests other then login '''
+        if json is None:
+            json = {}
+
+        try:
+            # Perform some very basic path input validation.
+            path = str(path)
+            if path[0] != '/':
+                msg = 'Value of <path> does not appear to be formated properly'
+                raise Exception(self._return_error(None, method, path, msg))
+            response, response_data = self.connection.send(path, json, method=method, headers=self.headers, force_basic_auth=True)
+            self._verify_response(response, method, path)
+            response_value = self._get_response_value(response_data)
+
+            return self._response_to_json(response_value)
+        except Exception as e:
+            if isinstance(e.message, dict):
+                if e.message.get('METHOD') is not None:
+                    return [e.message]
+                raise
+            else:
+                raise
+
+    def _verify_response(self, response, method, path):
+        ''' Process the return code and response object from DCNM '''
+        rc = response.getcode()
+        if rc == 200:
+            return
+        elif rc >= 400:
+            path = response.geturl()
+            msg = response.msg
+            raise Exception(self._return_error(rc, method, path, msg))
+        else:
+            msg = 'Unknown RETURN_CODE: {}'.format(rc)
+            raise Exception(self._return_error(rc, method, path, msg))
+
+    def _get_response_value(self, response_data):
+        ''' Extract string data from response_data returned from DCNM '''
+        return to_text(response_data.getvalue())
+
+    def _response_to_json(self, response_text):
+        ''' Convert response_text to json format '''
+        try:
+            return json.loads(response_text) if response_text else {}
+        # JSONDecodeError only available on Python 3.5+
+        except ValueError:
+            msg = 'Invalid JSON response: {}'.format(response_text)
+            raise ConnectionError(self._return_error(None, None, None, msg))
+
+    def _return_error(self, rc, method, path, error):
+        ''' Format error data returned in a raise with a consistent dict format '''
+        error_info = {}
+        error_info['RETURN_CODE'] = rc
+        error_info['METHOD'] = method
+        error_info['REQUEST_PATH'] = path
+        error_info['ERROR'] = error
+
+        return error_info


### PR DESCRIPTION
##### SUMMARY
This PR adds support for an `HTTPAPI` connection plugin for the NX-OS Data Center Network Manager (DCNM) Fabric Controller.  This PR also adds a test ansible module `dcnm_rest` that can be used to test any `method` and `path` combination with DCNM.

**Note:** I setup a branch called `dcnm_devel` as the main development branch for the dcnm integration project.  We can create feature branches here and then merge them back into `dcnm_devel`.  Eventually this will be moved into a collection but this will give us a space to collaborate.

##### ISSUE TYPE
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
dcnm

##### ADDITIONAL INFORMATION
The following information provides some initial design thoughts for the plugin and sample tests to better understand the workflow and code in this PR.

The `HTTPAPI` connection plugin architecture requires a `send_request` method wrapper that can be used to create the supporting headers and json data that is needed when sending REST API calls to DCNM.  Additionally the architecture allows for a `login(self, username, password)` function for devices that need a connection established before sending REST calls.  DCNM requires this so this PR defines a `login` method.

Additionally, the connection plugin always returns success or error data in the form of a list of dicts.

```python
[{key: value, key: value}]
```

Any error data that comes back from DCNM is first massaged into the following structure before returning.

```python
    "msg": [
        {
            "ERROR": "Error data", 
            "METHOD": "<REST API METHOD>", 
            "REQUEST_PATH": "<REST API PATH>", 
            "RETURN_CODE": RETURN_CODE
        }
    ]
```

##### EXAMPLE USAGE

For this example I am using the following `group_vars` settings.

File: group_vars/dcnm.yaml 

```yaml
---
ansible_ssh_user: admin 
ansible_ssh_pass: password 
ansible_network_os: dcnm
ansible_httpapi_validate_certs: False 
ansible_httpapi_use_ssl: True 
```

The following playbook can be used to get DCNM fabric information using the `dcnm_rest` test module.

```yaml
---
- hosts: dcnm
  gather_facts: no
  connection: httpapi

  tasks:
    - name: Connect to DCNM over httpapi
      dcnm_rest:
        method: GET
        path: /rest/control/fabrics/msd/fabric-associations
```

Here is sample response data that comes back for a successful session and one where an error occurs.  The error is for an invalid DCNM ip address.

**Success:**
```
ok: [192.168.1.1] => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "json_data": null, 
            "method": "GET", 
            "path": "/rest/control/fabrics/msd/fabric-associations"
        }
    }, 
    "response": [
        {
            "fabricId": 4, 
            "fabricName": "New_Fabric", 
            "fabricParent": "None", 
            "fabricState": "standalone", 
            "fabricTechnology": "VXLANFabric", 
            "fabricType": "Switch_Fabric"
        }
    ]
}

```

**Failure:**

```
fatal: [192.168.1.2]: FAILED! => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "json_data": null, 
            "method": "GET", 
            "path": "/rest/control/fabrics/msd/fabric-associations"
        }
    }, 
    "msg": [
        {
            "ERROR": "Error on attempt to connect and authenticate with DCNM controller: Could not connect to https://11.122.197.6:443/rest/logon: [Errno 60] Operation timed out", 
            "METHOD": "POST", 
            "REQUEST_PATH": "/rest/logon", 
            "RETURN_CODE": null
        }
    ]
}

```