### PR TITLE
dcnm_rest: Adding a fix to the post processing code

### DIFF
--- a/lib/ansible/modules/network/dcnm/dcnm_rest.py
+++ b/lib/ansible/modules/network/dcnm/dcnm_rest.py
@@ -94,10 +94,9 @@ def main():
     conn = Connection(module._socket_path)
     result['response'] = conn.send_request(method, path, json_data)
 
-    if isinstance(result['response'], list):
-        if result['response']:
-            if result['response'][0].get('ERROR'):
-                module.fail_json(msg=result['response'])
+    res = result['response']
+    if res and isinstance(res, list) and res[0].get['ERROR']:
+        module.fail_json(msg=result['response'])
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/network/dcnm/dcnm_rest.py
+++ b/lib/ansible/modules/network/dcnm/dcnm_rest.py
@@ -93,8 +93,11 @@ def main():
 
     conn = Connection(module._socket_path)
     result['response'] = conn.send_request(method, path, json_data)
-    if result['response'][0].get('ERROR'):
-        module.fail_json(msg=result['response'])
+
+    if isinstance(result['response'], list):
+        if result['response']:
+            if result['response'][0].get('ERROR'):
+                module.fail_json(msg=result['response'])
 
     module.exit_json(**result)
 


### PR DESCRIPTION
##### SUMMARY
Post processing code assumes all payloads are in list and dict format.
But, payloads with REST API response code 200 are just dict.

Example:

This is a response for vrf delete API call.

ok: [dcnmiac.cisco.com] => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "json_data": null, 
            "method": "DELETE", 
            "path": "/rest/top-down/fabrics/vxlan-shrishail-green-field/vrfs/ansible-vrf-13"
        }
    }, 
    "response": {}
}

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
dcnm