### PR TITLE
Make dcnm api return data consistent

### DIFF
--- a/lib/ansible/module_utils/network/dcnm/dcnm.py
+++ b/lib/ansible/module_utils/network/dcnm/dcnm.py
@@ -26,15 +26,13 @@ def get_fabric_inventory_details(module, fabric):
     ip_sn = dict()
     response = dcnm_send(module, method, path)
 
-    if response and isinstance(response, list):
-        response = response[0]
-        if response.get('RETURN_CODE') == 404:
-            # RC 404 - Object not found
-            return ip_sn
-        if response.get('RETURN_CODE') >= 400:
-            # Handle additional return codes as needed but for now raise
-            # for any error other then 404.
-            raise Exception(response)
+    if response.get('RETURN_CODE') == 404:
+        # RC 404 - Object not found
+        return ip_sn
+    if response.get('RETURN_CODE') >= 400:
+        # Handle additional return codes as needed but for now raise
+        # for any error other then 404.
+        raise Exception(response)
 
     for device in response.get('DATA'):
         ip = device.get('ipAddress')

--- a/lib/ansible/plugins/httpapi/dcnm.py
+++ b/lib/ansible/plugins/httpapi/dcnm.py
@@ -69,7 +69,7 @@ class HttpApi(HttpApiBase):
         except Exception as e:
             eargs = e.args[0]
             if isinstance(eargs, dict) and eargs.get('METHOD'):
-                return [eargs]
+                return eargs
             raise Exception(str(e))
 
     def _verify_response(self, response, method, path, rdata):


### PR DESCRIPTION
##### SUMMARY
This PR updates the data we return from DCNM to always use the same dictionary format for success and error cases.

```python
        info = {}
        info['RETURN_CODE'] = rc
        info['METHOD'] = method
        info['REQUEST_PATH'] = path
        info['MESSAGE'] = msg
        info['DATA'] = json_respond_data
```

Additional changes included in this PR:
* Updates to `lib/ansible/module_utils/network/dcnm/dcnm.py` to account for changes and a few `pep8` style/syntax updates.
* Updates to `lib/ansible/module_utils/network/dcnm/dcnm.py` to check errors using only the error code.  IMO other checks are not necessary.  I also added a raise for other errors but we can update as needed.


Here are some examples of data that gets returned for various rest api calls.

#### Successful POST

```
{
    'RETURN_CODE': 200,
    'METHOD': 'POST',
    'REQUEST_PATH': 'https://10.122.197.6:443/rest/interface',
    'MESSAGE': 'OK',
    'DATA': {}
}
```

#### Successful GET

```
{
    'RETURN_CODE': 200,
    'METHOD': 'GET',
    'REQUEST_PATH': 'https://10.122.197.6:443/rest/control/fabrics/msd/fabric-associations',
    'MESSAGE': 'OK',
    'DATA': [
        {
            'fabricId': 6,
            'fabricName': 'vxlan-shrishail-green-field',
            'fabricType': 'Switch_Fabric',
            'fabricState': 'standalone',
            'fabricParent': 'None',
            'fabricTechnology': 'VXLANFabric'
        }
    ]
}
```

#### ERROR CODE 500
```
[
    {
        'RETURN_CODE': 500,
        'METHOD': 'POST',
        'REQUEST_PATH': 'https://10.122.197.6:443/rest/interface',
        'MESSAGE': 'Internal Server Error',
        'DATA': [
            {
                'reportItemType': 'ERROR',
                'message': 'Invalid Serial number',
                'entity': 'HOX1821H035~loopback55',
                'line': 0,
                'column': 0
            }
        ]
    }
]
```
