### PR TITLE
Add playbook validator to common

### DIFF
--- a/lib/ansible/module_utils/network/dcnm/dcnm.py
+++ b/lib/ansible/module_utils/network/dcnm/dcnm.py
@@ -64,11 +64,7 @@ def validate_list_of_dicts(param_list, spec):
             valid_params_dict[param] = item
         normalized.append(valid_params_dict)
 
-    if invalid_params:
-        msg = 'Invalid parameters in playbook: {}'.format('\n'.join(invalid_params))
-        raise Exception(msg)
-
-    return(normalized)
+    return(normalized, invalid_params)
 
 
 def get_fabric_inventory_details(module, fabric):

--- a/lib/ansible/module_utils/network/dcnm/dcnm.py
+++ b/lib/ansible/module_utils/network/dcnm/dcnm.py
@@ -16,7 +16,59 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import socket
+from ansible.module_utils.common import validation
 from ansible.module_utils.connection import Connection
+
+def validate_list_of_dicts(param_list, spec):
+    """ Validate/Normalize playbook params. Will raise when invalid parameters found.
+    param_list: a playbook parameter list of dicts
+    spec: an argument spec dict
+          e.g. spec = dict(ip=dict(required=True, type='ipv4'),
+                           foo=dict(type='str', default='bar'))
+
+    return: list of normalized input data
+    """
+    v = validation
+    normalized = []
+    invalid_params = []
+    for list_entry in param_list:
+        valid_params_dict = {}
+        for param in spec:
+            item = list_entry.get(param)
+            if item is None:
+                if spec[param].get('required'):
+                    invalid_params.append('{} : Required parameter not found'.format(item))
+                else:
+                    item = spec[param].get('default')
+            else:
+                type = spec[param].get('type')
+                if type == 'str':
+                    item = v.check_type_str(item)
+                elif type == 'int':
+                    item = v.check_type_int(item)
+                elif type == 'bool':
+                    item = v.check_type_bool(item)
+                elif type == 'list':
+                    item = v.check_type_list(item)
+                elif type == 'dict':
+                    item = v.check_type_dict(item)
+                elif type == 'ipv4':
+                    address = item.split('/')[0]
+                    try:
+                        socket.inet_aton(address)
+                    except socket.error:
+                        invalid_params.append('{} : Invalid IPv4 address syntax'.format(item))
+                    if address.count('.') != 3:
+                        invalid_params.append('{} : Invalid IPv4 address syntax'.format(item))
+            valid_params_dict[param] = item
+        normalized.append(valid_params_dict)
+
+    if invalid_params:
+        msg = 'Invalid parameters in playbook: {}'.format('\n'.join(invalid_params))
+        raise Exception(msg)
+
+    return(normalized)
 
 
 def get_fabric_inventory_details(module, fabric):


### PR DESCRIPTION
##### SUMMARY
This is an input validator for a generic parameter list. I created this to handle `config` and `attach` param lists. 
The validator will check each populated input against its defined arg type and coerce it to the proper format if possible. Args that fail validation will be returned as a group error message and exception raised. This allows multiple errors to be found in one play without having to rerun after fixing each failure.

Example usage. I have a normalize method that defines arg specs for `config` (net_spec) and for `attach` (att_spec) lists.
```
    def normalize_inputs(self):
        net_spec = dict(
            net_name=dict(required=True, type='str'),
            net_id=dict(required=True, type='int'),
            vrf=dict(required=True, type='str'),
            #
            attach=dict(type='list'),
            deploy_net=dict(type='bool'),
            gw_ip=dict(type='ipv4'),
            vlan_id=dict(type='int'),
            template=dict(type='str', default='Default_Network_Universal'),
            template_ext=dict(type='str', default='Default_Network_Extension_Universal')
        )
        att_spec = dict(
            ip=dict(required=True, type='ipv4'),
            switch_name=dict(type='str'),
            ports=dict(required=True, type='list'),
            deploy=dict(type='bool', default=True)
        )
        want = self.want
        valid_net_list = validate_list_of_dicts(self.config, net_spec)    <-----<<

         ...
        for i in valid_net_list:
           ...
                valid_att_list = validate_list_of_dicts(i['attach'], att_spec)   <----<<
```
